### PR TITLE
Allow tracing without providing a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ def add(a, b)
 end
 ```
 
+You can use any of the trace methods without providing a block:
+
+```
+class Order < ApplicationRecord
+  include Trailer::Concern
+
+  after_update_commit :trace_state_change, if: -> { saved_change_to_state? }
+
+  def trace_state_change
+    trace_class(self, state_was: state_was)
+  end
+end
+```
+
 
 ### No Rails?
 

--- a/spec/trailer/concern_spec.rb
+++ b/spec/trailer/concern_spec.rb
@@ -35,6 +35,10 @@ class Tester
     end
   end
 
+  def test_no_yield(resource)
+    trace_event(:save, resource, {})
+  end
+
   def current_member
     OpenStruct.new(id: 456)
   end
@@ -133,6 +137,12 @@ RSpec.describe Trailer::Concern do
     it 'records the duration of the trace' do
       allow(Process).to receive(:clock_gettime).and_return(123, 456)
       subject.test_event(Model.new)
+      expect(store).to have_received(:write).with(hash_including(duration: 333_000))
+    end
+
+    it 'does not require a block' do
+      allow(Process).to receive(:clock_gettime).and_return(456, 789)
+      subject.test_no_yield(Model.new)
       expect(store).to have_received(:write).with(hash_including(duration: 333_000))
     end
   end


### PR DESCRIPTION
## Allow tracing without providing a block

[Clubhouse Story](https://app.clubhouse.io/shuttlerock/story/74652)



## How to test the PR

Trace without a block:

```
class Order < ApplicationRecord
  include Trailer::Concern

  after_update_commit :trace_state_change, if: -> { saved_change_to_state? }

  def trace_state_change
    trace_class(self, state_was: state_was)
  end
end
```

## Deployment Notes

None.